### PR TITLE
Fix missing tempfile import

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -1,6 +1,7 @@
 # mlflow_pipeline/src/training.py
-import os, time, pickle, json # Add json
+import os, time, pickle, json  # Add json
 from pathlib import Path
+import tempfile
 from typing import List, Tuple, Dict, Any # Add Dict, Any
 
 import numpy as np


### PR DESCRIPTION
## Summary
- ensure `tempfile` is imported in training module

## Testing
- `pytest -q tests/test_pipeline.py::TestPipeline.test_metric_row -vv` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_684094234be883308f2707dd74640315